### PR TITLE
Handling comma if Image is not last item in json list

### DIFF
--- a/image_utilities.sh
+++ b/image_utilities.sh
@@ -32,7 +32,7 @@ if [ $IMAGE_LIMIT -gt 0 ]; then
         log_and_echo "Number of images: $NUMBER_IMAGES and Image limit: $IMAGE_LIMIT"
         if [ $NUMBER_IMAGES -ge $IMAGE_LIMIT ]; then
             # create array of images name
-            ICE_IMAGES_ARRAY=$(grep ${REGISTRY_URL}/${IMAGE_NAME} inspect.log | awk '/Image/ {printf "%s\n", $2}' | sed 's/"//'g)
+            ICE_IMAGES_ARRAY=$(grep ${REGISTRY_URL}/${IMAGE_NAME} inspect.log | awk '/Image/ {printf "%s\n", $2}' | sed 's/"//'g | sed '/,//'g)
             # loop the list of spaces under the org and find the name of the images that are in used
             cf spaces > inspect.log 2> /dev/null
             RESULT=$?

--- a/image_utilities.sh
+++ b/image_utilities.sh
@@ -32,7 +32,7 @@ if [ $IMAGE_LIMIT -gt 0 ]; then
         log_and_echo "Number of images: $NUMBER_IMAGES and Image limit: $IMAGE_LIMIT"
         if [ $NUMBER_IMAGES -ge $IMAGE_LIMIT ]; then
             # create array of images name
-            ICE_IMAGES_ARRAY=$(grep ${REGISTRY_URL}/${IMAGE_NAME} inspect.log | awk '/Image/ {printf "%s\n", $2}' | sed 's/"//'g | sed '/,//'g)
+            ICE_IMAGES_ARRAY=$(grep ${REGISTRY_URL}/${IMAGE_NAME} inspect.log | awk '/Image/ {printf "%s\n", $2}' | sed 's/"//'g | sed 's/,//'g)
             # loop the list of spaces under the org and find the name of the images that are in used
             cf spaces > inspect.log 2> /dev/null
             RESULT=$?


### PR DESCRIPTION
Currently on beta3, the json returned for ice inspect images has fields after "Image":, which leaves a trailing comma.  The trailing comma breaks the image cleanup code. 

This fixes the problem, and does not fail when there isn't a trailing comma.
