### PR TITLE
WI: 91084 - disallow ./ as ARCHIVE_DIR

### DIFF
--- a/_init.sh
+++ b/_init.sh
@@ -273,13 +273,13 @@ if [ -z $WORKSPACE ]; then
 fi 
 
 if [ -z $ARCHIVE_DIR ]; then 
-    echo "${label_color}ARCHIVE_DIR was not set, setting to WORKSPACE/archive ${no_color}"
+    echo "${label_color}ARCHIVE_DIR was not set, setting to WORKSPACE ${no_color}"
     export ARCHIVE_DIR="${WORKSPACE}"
 fi 
 
 if [ "${ARCHIVE_DIR}" == "./" ]; then
-   echo "${label_color}ARCHIVE_DIR set relative, adjusting to WORKSPACE/archive ${no_color}"
-   export ARCHIVE_DIR="${WORKSPACE}"
+   echo "${label_color}ARCHIVE_DIR set relative, adjusting to current dir absolute ${no_color}"
+   export ARCHIVE_DIR=`pwd`
 fi
 
 if [ -d $ARCHIVE_DIR ]; then

--- a/_init.sh
+++ b/_init.sh
@@ -277,6 +277,11 @@ if [ -z $ARCHIVE_DIR ]; then
     export ARCHIVE_DIR="${WORKSPACE}"
 fi 
 
+if [ "${ARCHIVE_DIR}" == "./" ] then
+   echo "${label_color}ARCHIVE_DIR set relative, adjusting to WORKSPACE/archive ${no_color}"
+   export ARCHIVE_DIR="${WORKSPACE}"
+fi
+
 if [ -d $ARCHIVE_DIR ]; then
   echo "Archiving to $ARCHIVE_DIR"
 else 

--- a/_init.sh
+++ b/_init.sh
@@ -277,7 +277,7 @@ if [ -z $ARCHIVE_DIR ]; then
     export ARCHIVE_DIR="${WORKSPACE}"
 fi 
 
-if [ "${ARCHIVE_DIR}" == "./" ] then
+if [ "${ARCHIVE_DIR}" == "./" ]; then
    echo "${label_color}ARCHIVE_DIR set relative, adjusting to WORKSPACE/archive ${no_color}"
    export ARCHIVE_DIR="${WORKSPACE}"
 fi

--- a/_init.sh
+++ b/_init.sh
@@ -273,19 +273,19 @@ if [ -z $WORKSPACE ]; then
 fi 
 
 if [ -z $ARCHIVE_DIR ]; then 
-    echo "${label_color}ARCHIVE_DIR was not set, setting to WORKSPACE ${no_color}"
+    echo -e "${label_color}ARCHIVE_DIR was not set, setting to WORKSPACE ${no_color}"
     export ARCHIVE_DIR="${WORKSPACE}"
 fi 
 
 if [ "${ARCHIVE_DIR}" == "./" ]; then
-   echo "${label_color}ARCHIVE_DIR set relative, adjusting to current dir absolute ${no_color}"
+   echo -e "${label_color}ARCHIVE_DIR set relative, adjusting to current dir absolute ${no_color}"
    export ARCHIVE_DIR=`pwd`
 fi
 
 if [ -d $ARCHIVE_DIR ]; then
-  echo "Archiving to $ARCHIVE_DIR"
+  echo -e "Archiving to $ARCHIVE_DIR"
 else 
-  echo "Creating archive directory $ARCHIVE_DIR"
+  echo -e "Creating archive directory $ARCHIVE_DIR"
   mkdir $ARCHIVE_DIR 
 fi 
 export LOG_DIR=$ARCHIVE_DIR


### PR DESCRIPTION
default ARCHIVE_DIR is ./ - if the user changes dir mid script, this can leave 'archived' files in different places, some in places that the stage won't expect to pick them up from.  this change makes it = $WORKSPACE, which is what ./ would be at the start of the script anyway, just absolute.
