### PR TITLE
WI 91084 revisit - archive dir

### DIFF
--- a/_init.sh
+++ b/_init.sh
@@ -272,15 +272,10 @@ if [ -z $WORKSPACE ]; then
     exit 1
 fi 
 
-if [ -z $ARCHIVE_DIR ]; then 
-    echo -e "${label_color}ARCHIVE_DIR was not set, setting to WORKSPACE ${no_color}"
-    export ARCHIVE_DIR="${WORKSPACE}"
-fi 
-
-if [ "${ARCHIVE_DIR}" == "./" ]; then
-   echo -e "${label_color}ARCHIVE_DIR set relative, adjusting to current dir absolute ${no_color}"
-   export ARCHIVE_DIR=`pwd`
-fi
+# adjusting archive dir to point to workspace, so that it
+# works consistently.  User will be pointed to use $WORKSPACE
+# instead in the sample script.
+export ARCHIVE_DIR="${WORKSPACE}"
 
 if [ -d $ARCHIVE_DIR ]; then
   echo -e "Archiving to $ARCHIVE_DIR"

--- a/extension.json
+++ b/extension.json
@@ -77,10 +77,10 @@ else
     exit 1
 fi  
 
-########################################################################################
-# Copy any artifacts that will be needed for deployment and testing to $archive_dir    #
-########################################################################################
-echo \"IMAGE_NAME=${FULL_REPOSITORY_NAME}\" >> ${ARCHIVE_DIR}/build.properties",
+######################################################################################
+# Copy any artifacts that will be needed for deployment and testing to $WORKSPACE    #
+######################################################################################
+echo \"IMAGE_NAME=${FULL_REPOSITORY_NAME}\" >> ${WORKSPACE}/build.properties",
             "label_key": "COMMAND_KEY",
             "desc_key": "COMMAND_DESC"
         }


### PR DESCRIPTION
Revisiting, since last fix did not work.  This converts to using WORKSPACE where the user can see it (since that's an absolute path), and adjusting ARCHIVE_DIR internally to be the same where we can see it.  We can't change it in the user's script, since that's pre-substituted by IDS, so believe this to be the simplest and least confusing option.
