### PR TITLE
Improvement to BDD tests

### DIFF
--- a/bddTests/environment.py
+++ b/bddTests/environment.py
@@ -39,8 +39,8 @@ def before_feature(context, feature):
     #Cleaning up any hanging on images
     try:
         print(subprocess.check_output("ice images | grep "+os.getenv("IMAGE_NAME")+" | awk '{print $6}' | xargs -n 1 ice rmi", shell=True))
-        print
         print("Waiting 120 seconds after removal of images")
+        print
         time.sleep(120)
     except subprocess.CalledProcessError as e:
         print ("No images found, continuing with test setup")

--- a/bddTests/environment.py
+++ b/bddTests/environment.py
@@ -40,8 +40,8 @@ def before_feature(context, feature):
     try:
         print(subprocess.check_output("ice images | grep "+os.getenv("IMAGE_NAME")+" | awk '{print $6}' | xargs -n 1 ice rmi", shell=True))
         print
-        print("Waiting 60 seconds after removal of images")
-        time.sleep(60)
+        print("Waiting 120 seconds after removal of images")
+        time.sleep(120)
     except subprocess.CalledProcessError as e:
         print ("No images found, continuing with test setup")
         print (e.cmd)
@@ -70,15 +70,15 @@ def before_tag(context, tag):
                 print(subprocess.check_output("pwd", shell=True));
                 try:
                     print("ice build -t "+appPrefix+str(version) +" .")
-                    print(subprocess.check_output("ice build -t "+appPrefix+str(version) +" .", shell=True))
                     print
+                    subprocess.check_output("ice build -t "+appPrefix+str(version) +" .", shell=True)
                 except subprocess.CalledProcessError as e:
                     print (e.cmd)
                     print (e.output)
                     raise e
                 increment_app_version()
                 count = count - 1
-            time.sleep(10)
+            time.sleep(20)
             print("ice images")
             print(subprocess.check_output("ice images", shell=True))
         if command == "useimages":
@@ -87,7 +87,7 @@ def before_tag(context, tag):
             while count > 0:
                 print("Starting container: "+containerName(version))
                 try:
-                    print(subprocess.check_output("ice run --name "+containerName(version) +" "+appPrefix+str(version), shell=True))
+                    subprocess.check_output("ice run --name "+containerName(version) +" "+appPrefix+str(version), shell=True)
                     print 
                 except subprocess.CalledProcessError as e:
                     print (e.cmd)
@@ -96,7 +96,7 @@ def before_tag(context, tag):
                     raise e
                 version = version + 1
                 count = count - 1
-            time.sleep(10)
+            time.sleep(20)
             print("ice ps")
             print(subprocess.check_output("ice ps", shell=True))
             
@@ -195,14 +195,15 @@ def after_scenario(context, scenario):
             if m:
                 try:
                     print(subprocess.check_output("ice rmi "+m.group(0), shell=True))
+                    print
                 except subprocess.CalledProcessError as e:
                     print ("ERROR return code "+ str(e.returncode) + " for ice rmi "+m.group(0))
                     print (e.cmd)
                     print (e.output)
                     print
-        print("Pausing for 120 seconds to allow images to fully delete")
-        time.sleep(120)
-    #don't reuse the last app version we used, so move up one always
+        print("Finished cleaning up images.")
+        print
+    #don't reuse the app version created by the build script, so move up one always
     increment_app_version()
     
 #def after_tag(context, tag):

--- a/bddTests/environment.py
+++ b/bddTests/environment.py
@@ -6,6 +6,9 @@ import time
 
 
 def get_app_version():
+    env = os.environ["APPLICATION_VERSION"]
+    if env is None:
+        os.environ["APPLICATION_VERSION"] = "31"
     return os.environ["APPLICATION_VERSION"]
     
 def set_app_version(ver):

--- a/bddTests/environment.py
+++ b/bddTests/environment.py
@@ -32,7 +32,7 @@ def before_feature(context, feature):
     os.environ["ARCHIVE_DIR"] = "."
     os.environ["IMAGE_NAME"] = "bddapp"
     context.appName = os.environ["IMAGE_NAME"]
-    set_app_version(context, 31)
+    set_app_version(31)
     #Cleaning up any hanging on containers
     cleanupContainers()
         

--- a/bddTests/environment.py
+++ b/bddTests/environment.py
@@ -32,7 +32,7 @@ def before_feature(context, feature):
     os.environ["ARCHIVE_DIR"] = "."
     os.environ["IMAGE_NAME"] = "bddapp"
     context.appName = os.environ["IMAGE_NAME"]
-    set_app_ver(context, 31)
+    set_app_version(context, 31)
     #Cleaning up any hanging on containers
     cleanupContainers()
         

--- a/bddTests/environment.py
+++ b/bddTests/environment.py
@@ -15,7 +15,7 @@ def before_feature(context, feature):
     os.chdir("simpleDocker")
     #os.mkdir("archive")
     os.environ["ARCHIVE_DIR"] = "."
-    os.environ["IMAGE_NAME"] = "fakeapp"
+    os.environ["IMAGE_NAME"] = "bddapp"
     context.appName = os.environ["IMAGE_NAME"]
     os.environ["APPLICATION_VERSION"] = "30"
     context.appVer = os.environ["APPLICATION_VERSION"]

--- a/bddTests/environment.py
+++ b/bddTests/environment.py
@@ -75,7 +75,18 @@ def before_tag(context, tag):
                 except subprocess.CalledProcessError as e:
                     print (e.cmd)
                     print (e.output)
-                    raise e
+                    print ("BUILD COMMAND FAILED, retrying in 10 seconds:")
+                    print
+                    time.sleep(10)
+                    print("ice build -t "+appPrefix+str(version) +" .")
+                    print
+                    try:
+                        subprocess.check_output("ice build -t "+appPrefix+str(version) +" .", shell=True)
+                    except subprocess.CalledProcessError as d:
+                        print (d.cmd)
+                        print (d.output)
+                        print ("BUILD COMMAND RETRY FAILED, failing test case")
+                        raise d
                 increment_app_version()
                 count = count - 1
             time.sleep(20)

--- a/bddTests/imageCleanup.feature
+++ b/bddTests/imageCleanup.feature
@@ -1,7 +1,8 @@
 Feature: Task 84101 - Build: image cleanup in build extension
 As a pipeline user I want to have an image quota in the build job to limit images so that I can both version images, and maintain an organized image registry that is within the registry limits.
 
-@createimages1 @smalltest
+@createimages1
+@smalltest
 Scenario: Start with less images
 Given I have a setup pipeline with a Container Image Build Stage
 And I have set the number images to keep to a value below the ICS image limit

--- a/bddTests/imageCleanup.feature
+++ b/bddTests/imageCleanup.feature
@@ -1,7 +1,7 @@
 Feature: Task 84101 - Build: image cleanup in build extension
 As a pipeline user I want to have an image quota in the build job to limit images so that I can both version images, and maintain an organized image registry that is within the registry limits.
 
-@createimages1
+@createimages1 @smalltest
 Scenario: Start with less images
 Given I have a setup pipeline with a Container Image Build Stage
 And I have set the number images to keep to a value below the ICS image limit

--- a/bddTests/setup_log_and_echo.sh
+++ b/bddTests/setup_log_and_echo.sh
@@ -1,0 +1,56 @@
+
+if [[ ! "$(declare -f -F log_and_echo)" ]]; then
+    echo "Setting up log_and_echo to just echo with color"
+    INFO="INFO_LEVEL"
+    LABEL="LABEL_LEVEL"
+    WARN="WARN_LEVEL"
+    ERROR="ERROR_LEVEL"
+
+    INFO_LEVEL=4
+    WARN_LEVEL=2
+    ERROR_LEVEL=1
+    OFF_LEVEL=0
+    
+    log_and_echo() {
+        local MSG_TYPE="$1"
+        if [ "$INFO" == "$MSG_TYPE" ]; then
+            shift
+            local pre=""
+            local post=""
+        elif [ "$LABEL" == "$MSG_TYPE" ]; then
+            shift
+            local pre="${label_color}"
+            local post="${no_color}"
+        elif [ "$WARN" == "$MSG_TYPE" ]; then
+            shift
+            local pre="${label_color}"
+            local post="${no_color}"
+        elif [ "$ERROR" == "$MSG_TYPE" ]; then
+            shift
+            local pre="${red}"
+            local post="${no_color}"
+        else
+            #NO MSG type specified; fall through to INFO level
+            #Do not shift
+            local pre=""
+            local post=""
+        fi
+        local L_MSG=`echo -e "$*"`
+        echo -e "${pre}${L_MSG}${post}"
+    }
+    export -f log_and_echo
+	# export message types for log_and_echo
+	# ERRORs will be collected
+	export INFO
+	export LABEL
+	export WARN
+	export ERROR
+
+	#export logging levels for log_and_echo
+	# messages will be logged if LOGGER_LEVEL is set to or above the LEVEL
+	# default LOGGER_LEVEL is WARN_LEVEL
+	export INFO_LEVEL
+	export WARN_LEVEL
+	export ERROR_LEVEL
+	export OFF_LEVEL
+fi


### PR DESCRIPTION
changed image name to bddapp from fakeapp.
put dummy log_and_echo setup in script
increment APPLICATION_VERSION throughout test, so we aren't re-using image tags
reduced/removed sleeps in general, since we aren't reusing image tags
retry once on ice build failure
