### PR TITLE
Bdd tests

### DIFF
--- a/bddTests/environment.py
+++ b/bddTests/environment.py
@@ -108,7 +108,7 @@ def cleanupImages(context, pause=False):
     #cleanup images
     imageList = subprocess_retry(context, "ice images", False)
     lines = imageList.splitlines()
-    imageMatcher = re.compile(os.getenv("REGISTRY_URL") +"/"+ os.getenv("IMAGE_NAME"))
+    imageMatcher = re.compile(os.getenv("REGISTRY_URL") +"/"+ os.getenv("IMAGE_NAME")+"\S*:\S+")
     imagesFound = False
     for line in lines:
         m = imageMatcher.search(line)
@@ -128,7 +128,7 @@ def cleanupContainers(context):
     for m in re.finditer(os.environ["IMAGE_NAME"]+"\d+C", psOutput):
         print("Removing container: "+m.group(0))
         subprocess_retry(context, "ice stop "+m.group(0), True)
-        for i in range(15):
+        for i in range(30):
             inspectOutput = subprocess_retry(context, "ice inspect " + m.group(0), False)
             statusMatcher = re.compile("\"Status\": \"(\S*)\"")
             mInspect = statusMatcher.search(inspectOutput)
@@ -139,7 +139,7 @@ def cleanupContainers(context):
                 if (status != "Running"):
                     break
             time.sleep(6)
-        subprocess_retry(context, "ice rm "+m.group(0), True)
+        subprocess_retry(context, "ice rm --force "+m.group(0), True)
 
 def after_scenario(context, scenario):
     matcher = re.compile("(\D*)(\d+)")

--- a/bddTests/environment.py
+++ b/bddTests/environment.py
@@ -108,7 +108,7 @@ def cleanupImages(context, pause=False):
     #cleanup images
     imageList = subprocess_retry(context, "ice images", False)
     lines = imageList.splitlines()
-    imageMatcher = re.compile(os.getenv("REGISTRY_URL") +"/"+ os.getenv("IMAGE_NAME")+":\\d+")
+    imageMatcher = re.compile(os.getenv("REGISTRY_URL") +"/"+ os.getenv("IMAGE_NAME"))
     imagesFound = False
     for line in lines:
         m = imageMatcher.search(line)

--- a/bddTests/steps/imageDriver.py
+++ b/bddTests/steps/imageDriver.py
@@ -15,17 +15,17 @@ def step_impl(context):
     os.environ["IMAGE_LIMIT"]="3"
     
 def get_appImage_count(context):
-    imageList = subprocess_retry(context, "ice images | grep "+context.appName, True)
-    lines = imageList.splitlines()
-    Count = int(len(lines))
+    imageList = subprocess_retry(context, "ice images", True)
+    matches = re.findall(context.appName+":\d+", imageList)
+    Count = int(len(matches))
     print (Count)
     print
     return Count
 
 def get_totImage_count(context):
-    imageList = subprocess_retry(context, "ice images | grep "+os.environ["NAMESPACE"]+"/", True)
-    lines = imageList.splitlines()
-    Count = int(len(lines))
+    imageList = subprocess_retry(context, "ice images", True)
+    matches = re.findall(os.environ["NAMESPACE"]+"/")
+    Count = int(len(matches))
     print (Count)
     print
     return Count
@@ -74,7 +74,7 @@ def step_impl(context):
 def step_impl(context):
     tries = 0
     while tries < 6:
-        imageList = subprocess_retry(context, "ice images | grep "+context.appName, True)
+        imageList = subprocess_retry(context, "ice images", True)
         matcher = re.compile(context.appName+":"+get_app_version())
         m = matcher.search(imageList)
         if (m):
@@ -94,9 +94,9 @@ def step_impl(context):
     assert (context.preCount > int(os.environ["IMAGE_LIMIT"]))
     
 def check_images_deleted_until_under_limit(context, limit):
-    imageList = subprocess_retry(context, "ice images | grep \""+context.appName+":[0-9]\\+\"", True)
-    lines = imageList.splitlines()
-    assert (len(lines) == limit)
+    imageList = subprocess_retry(context, "ice images", True)
+    matches = re.findall(context.appName+":\d+", imageList)
+    assert (len(matches) == limit)
     ver = int(get_app_version())
     count = 0
     while (count < limit):
@@ -135,8 +135,8 @@ def step_impl(context):
         print (unusedVersions)
         print
         assert (unusedVersions)
+        imageList = subprocess_retry(context, "ice images", True)
         for ver in unusedVersions:
-            imageList = subprocess_retry(context, "ice images | grep "+context.appName, True)
             matcher = re.compile(context.appName+":"+str(ver))
             m = matcher.search(imageList)
             assert m is None
@@ -145,7 +145,7 @@ def step_impl(context):
 def step_impl(context):
     usedCount = get_used_count(context)
     assert usedCount > 0
-    imageList = subprocess_retry(context, "ice images | grep "+context.appName, True)
+    imageList = subprocess_retry(context, "ice images", True)
     version = int(get_app_version())-usedCount
     while usedCount > 0:
         matcher = re.compile(context.appName+":"+str(version))
@@ -180,7 +180,7 @@ def step_impl(context):
 def step_impl(context):
     tries = 0
     while tries < 6:
-        imageList = subprocess_retry(context, "ice images | grep "+context.appName, True)
+        imageList = subprocess_retry(context, "ice images", True)
         matcher = re.compile(context.appName+":"+get_app_version())
         m = matcher.search(imageList)
         if (m):
@@ -237,8 +237,8 @@ def step_impl(context):
 
 
 def check_for_image(context, fullImgName):
-    output = subprocess_retry(context, "ice inspect images | grep "+fullImgName, False)
-    return output 
+    output = subprocess_retry(context, "ice inspect images", False)
+    return re.search(fullImgName, output) 
 
 @then(u'the images in the form of image_namexx will not be deleted')
 def step_impl(context):


### PR DESCRIPTION
removing calls to grep from ice calls prevents retries when grep returns no matches.

increased the number of times we check for a stopped container and then use --force tag either way to remove the container

modified the image cleanup code to clean images we create with similar names, such as bddappXXX:tag instead of just names in the form of bddapp:##
