### PR TITLE
Do not remove special images in steps and in image cleanup code

### DIFF
--- a/bddTests/steps/imageDriver.py
+++ b/bddTests/steps/imageDriver.py
@@ -243,13 +243,11 @@ def check_for_image(context, fullImgName):
 @then(u'the images in the form of image_namexx will not be deleted')
 def step_impl(context):
     assert check_for_image(context, context.imgxx)
-    subprocess_retry(context, "ice rmi "+context.imgxx, True)
 
 
 @then(u'the images tagged with an alpha-string will not be deleted')
 def step_impl(context):
     assert check_for_image(context, context.img_tag)
-    subprocess_retry(context, "ice rmi "+context.img_tag, True)
     
     
 @given(u'I want to generate some exceptions')


### PR DESCRIPTION
special images are now removed in image cleanup code, so they should not be removed in the test case steps to prevent race condition where the image is removed but not yet removed from the ice images list.
